### PR TITLE
Fix `InputRange#toString`

### DIFF
--- a/src/input-range.ts
+++ b/src/input-range.ts
@@ -131,7 +131,7 @@ export class InputRange implements ReadonlyTextRange {
 
   /** Get the contents of the range as a string. */
   toString(): string {
-    return this.#createCloneRange.toString();
+    return this.#createCloneRange().toString();
   }
 
   /**


### PR DESCRIPTION
Add missing parentheses - overlooked this when changing that method from a getter to a regular method