### PR TITLE
Fix RTL/alternative directions support

### DIFF
--- a/src/input-style-clone-element.ts
+++ b/src/input-style-clone-element.ts
@@ -110,7 +110,10 @@ export class InputStyleCloneElement extends CustomHTMLElement {
     this.#updateText();
 
     this.#styleObserver.observe(input, {
-      attributeFilter: ["style"],
+      attributeFilter: [
+        "style",
+        "dir", // users can right-click in some browsers to change the text direction dynamically
+      ],
     });
     this.#resizeObserver.observe(input);
 

--- a/src/input-style-clone-element.ts
+++ b/src/input-style-clone-element.ts
@@ -244,7 +244,12 @@ export class InputStyleCloneElement extends CustomHTMLElement {
 // into their shorthand (e.g. padding-top, padding-bottom etc. -> padding),
 // so we have to list every single property explicitly.
 const propertiesToCopy = [
-  "direction", // RTL support
+  // RTL / vertical writing modes support:
+  "direction",
+  "writingMode",
+  "unicodeBidi",
+  "textOrientation",
+
   "boxSizing",
 
   "borderTopWidth",


### PR DESCRIPTION
- Fixes #2

Turns out this wasn't _just_ adding more CSS properties -- we already were copying `direction`. The other problem was that we weren't refreshing the styling when the direction was changed by the user. This is easily fixed by observing the `dir` property using the already-existing `MutationObserver`. 

<img width="859" alt="working demo in RTL mode" src="https://github.com/iansan5653/dom-input-range/assets/2294248/98a970de-b86d-4e5b-a998-62cdef5ea63e">
