### PR TITLE
Allow `InputStyleCloneElement` to be constructed directly

### DIFF
--- a/src/input-style-clone-element.ts
+++ b/src/input-style-clone-element.ts
@@ -60,6 +60,14 @@ export class InputStyleCloneElement extends CustomHTMLElement {
     return clone;
   }
 
+  /**
+   * Connect this instance to a target input element and insert this instance into the DOM in the correct location.
+   * 
+   * NOTE: calling the static `for` method is nearly always preferable as it will reuse an existing clone if available.
+   * However, if reusing clones is problematic (ie, if the clone needs to be mutated), a clone can be constructed
+   * directly with `new InputStyleCloneElement()` and then bound to an input and inserted into the DOM with
+   * `clone.connect(target)`.
+   */
   connect(input: InputElement) {
     this.#inputRef = new WeakRef(input);
 

--- a/src/input-style-clone-element.ts
+++ b/src/input-style-clone-element.ts
@@ -62,7 +62,7 @@ export class InputStyleCloneElement extends CustomHTMLElement {
 
   /**
    * Connect this instance to a target input element and insert this instance into the DOM in the correct location.
-   * 
+   *
    * NOTE: calling the static `for` method is nearly always preferable as it will reuse an existing clone if available.
    * However, if reusing clones is problematic (ie, if the clone needs to be mutated), a clone can be constructed
    * directly with `new InputStyleCloneElement()` and then bound to an input and inserted into the DOM with


### PR DESCRIPTION
Allows constructing `InputStyleCloneElement` directly with `new InputStyleCloneElement()` (no constructor parameters). This functionality is expected by DOM APIs like `cloneNode`.

Attempting to then insert the constructed element will result in it removing itself from the DOM tree since an `InputStyleCloneElement` cannot function without a target input element to clone. Instead, the clone must be bound with `connect(target)`. Or, preferably, the clone can still be reused from the registry with `InputStyleCloneElement.for(target)`.

- Fixes https://github.com/iansan5653/dom-input-range/issues/5